### PR TITLE
将($\beta)$修正为($\beta$)

### DIFF
--- a/1-Manuscript-CN/Section/Section2.tex
+++ b/1-Manuscript-CN/Section/Section2.tex
@@ -41,7 +41,7 @@
 Embedded module with ribs and pin-fins embedded in microchannel heat sink below chip.
 \cref{tab:structure-parameter} shows the geometric parameters of the embedded module.
 To investigate the effect of ribs and pin-fins on fluid flow and heat transfer on the embedded module in MCHS-RPFEM, three parameters were selected to be varied.
-These three parameters are relative rib height ($\alpha$), relative pin-fin height ($\beta)$, and relative number of auxiliary channels ($\gamma$).
+These three parameters are relative rib height ($\alpha$), relative pin-fin height ($\beta$), and relative number of auxiliary channels ($\gamma$).
 
 \begin{table}[htbp]
     \centering


### PR DESCRIPTION
之前($\beta)$右括号填写在行内公式里，导致左右括号格式不一致，现将括号移动至行内公式外修复该问题。